### PR TITLE
feat: split exam and pharmacy queues

### DIFF
--- a/app/api/queue/done/route.ts
+++ b/app/api/queue/done/route.ts
@@ -1,8 +1,15 @@
 export const runtime = 'nodejs';
-import { NextResponse } from 'next/server';
+import { NextRequest, NextResponse } from 'next/server';
 import { doneCurrent } from '@/lib/store';
+import { Room } from '@/lib/types';
 export const dynamic = 'force-dynamic';
-export async function POST() {
-  const n = doneCurrent();
+function getRoom(req: NextRequest): Room {
+  const r = req.nextUrl.searchParams.get('room');
+  return r === 'exam' || r === 'pharmacy' ? r : 'pharmacy';
+}
+
+export async function POST(req: NextRequest) {
+  const room = getRoom(req);
+  const n = doneCurrent(room);
   return NextResponse.json({ ok: true, current: n });
 }

--- a/app/api/queue/next/route.ts
+++ b/app/api/queue/next/route.ts
@@ -1,8 +1,15 @@
 export const runtime = 'nodejs';
-import { NextResponse } from 'next/server';
+import { NextRequest, NextResponse } from 'next/server';
 import { nextQueue } from '@/lib/store';
+import { Room } from '@/lib/types';
 export const dynamic = 'force-dynamic';
-export async function POST() {
-  const n = nextQueue();
+function getRoom(req: NextRequest): Room {
+  const r = req.nextUrl.searchParams.get('room');
+  return r === 'exam' || r === 'pharmacy' ? r : 'pharmacy';
+}
+
+export async function POST(req: NextRequest) {
+  const room = getRoom(req);
+  const n = nextQueue(room);
   return NextResponse.json({ ok: true, current: n });
 }

--- a/app/api/queue/repeat/route.ts
+++ b/app/api/queue/repeat/route.ts
@@ -1,8 +1,15 @@
 export const runtime = 'nodejs';
-import { NextResponse } from 'next/server';
+import { NextRequest, NextResponse } from 'next/server';
 import { repeatCurrent } from '@/lib/store';
+import { Room } from '@/lib/types';
 export const dynamic = 'force-dynamic';
-export async function POST() {
-  const n = repeatCurrent();
+function getRoom(req: NextRequest): Room {
+  const r = req.nextUrl.searchParams.get('room');
+  return r === 'exam' || r === 'pharmacy' ? r : 'pharmacy';
+}
+
+export async function POST(req: NextRequest) {
+  const room = getRoom(req);
+  const n = repeatCurrent(room);
   return NextResponse.json({ ok: true, current: n });
 }

--- a/app/api/queue/route.ts
+++ b/app/api/queue/route.ts
@@ -1,16 +1,24 @@
 export const runtime = 'nodejs';
 import { NextRequest, NextResponse } from 'next/server';
 import { addQueue, getSnapshot } from '@/lib/store';
+import { Room } from '@/lib/types';
 
 export const dynamic = 'force-dynamic';
 
-export async function GET() {
-  return NextResponse.json(getSnapshot());
+function getRoom(req: NextRequest): Room {
+  const r = req.nextUrl.searchParams.get('room');
+  return r === 'exam' || r === 'pharmacy' ? r : 'pharmacy';
+}
+
+export async function GET(req: NextRequest) {
+  const room = getRoom(req);
+  return NextResponse.json(getSnapshot(room));
 }
 export async function POST(req: NextRequest) {
+  const room = getRoom(req);
   const body = await req.json().catch(() => ({}));
   if (body.action === 'add') {
-    const item = addQueue();
+    const item = addQueue(room);
     return NextResponse.json({ ok: true, added: item });
   }
   return NextResponse.json({ ok: false, error: 'Unknown action' }, { status: 400 });

--- a/app/api/queue/skip/route.ts
+++ b/app/api/queue/skip/route.ts
@@ -1,8 +1,15 @@
 export const runtime = 'nodejs';
-import { NextResponse } from 'next/server';
+import { NextRequest, NextResponse } from 'next/server';
 import { skipCurrent } from '@/lib/store';
+import { Room } from '@/lib/types';
 export const dynamic = 'force-dynamic';
-export async function POST() {
-  const n = skipCurrent();
+function getRoom(req: NextRequest): Room {
+  const r = req.nextUrl.searchParams.get('room');
+  return r === 'exam' || r === 'pharmacy' ? r : 'pharmacy';
+}
+
+export async function POST(req: NextRequest) {
+  const room = getRoom(req);
+  const n = skipCurrent(room);
   return NextResponse.json({ ok: true, current: n });
 }

--- a/app/api/settings/counter/route.ts
+++ b/app/api/settings/counter/route.ts
@@ -2,19 +2,27 @@ export const runtime = 'nodejs';
 
 import { NextRequest, NextResponse } from 'next/server';
 import { getSnapshot, setCounterName } from '@/lib/store';
+import { Room } from '@/lib/types';
 
 export const dynamic = 'force-dynamic';
 
-export async function GET() {
-  const { counterName } = getSnapshot();
+function getRoom(req: NextRequest): Room {
+  const r = req.nextUrl.searchParams.get('room');
+  return r === 'exam' || r === 'pharmacy' ? r : 'pharmacy';
+}
+
+export async function GET(req: NextRequest) {
+  const room = getRoom(req);
+  const { counterName } = getSnapshot(room);
   return NextResponse.json({ counterName });
 }
 
 export async function POST(req: NextRequest) {
+  const room = getRoom(req);
   const body = await req.json().catch(() => ({}));
   if (typeof body.counterName === 'string') {
-    setCounterName(body.counterName.trim());
-    const { counterName } = getSnapshot();
+    setCounterName(room, body.counterName.trim());
+    const { counterName } = getSnapshot(room);
     return NextResponse.json({ ok: true, counterName });
   }
   return NextResponse.json({ ok: false, error: 'counterName is required' }, { status: 400 });

--- a/app/display/page.tsx
+++ b/app/display/page.tsx
@@ -1,16 +1,25 @@
-
 'use client';
 import React from 'react';
+import type { Room } from '@/lib/types';
 
 type Snapshot = { current: number|null; items: { number: number; status: string; createdAt: number }[]; tailNumber: number; counterName: string };
 
 export default function DisplayPage() {
+  return (
+    <main style={{ width: '100%', height: '100vh', background: '#030712', color: '#e5e7eb', display: 'grid', gridTemplateColumns: '1fr 1fr' }}>
+      <Board room="exam" />
+      <Board room="pharmacy" />
+    </main>
+  );
+}
+
+function Board({ room }: { room: Room }) {
   const [snap, setSnap] = React.useState<Snapshot | null>(null);
   const [lastNumber, setLastNumber] = React.useState<number | null>(null);
   const [chime, setChime] = React.useState(false);
 
   const refresh = React.useCallback(async () => {
-    const res = await fetch('/api/queue', { cache: 'no-store' });
+    const res = await fetch(`/api/queue?room=${room}`, { cache: 'no-store' });
     const data: Snapshot = await res.json();
     const nextCurrent = data.current ?? null;
     if (chime && nextCurrent && nextCurrent !== lastNumber) {
@@ -21,7 +30,7 @@ export default function DisplayPage() {
     }
     setLastNumber(nextCurrent ?? null);
     setSnap(data);
-  }, [chime, lastNumber]);
+  }, [room, chime, lastNumber]);
 
   React.useEffect(() => {
     refresh();
@@ -43,9 +52,9 @@ export default function DisplayPage() {
   };
 
   return (
-    <main style={{ width: '100%', height: '100vh', background: '#030712', color: '#e5e7eb', display: 'grid', gridTemplateColumns: '1.2fr 1fr' }}>
+    <div style={{ display: 'grid', gridTemplateColumns: '1.2fr 1fr', height: '100%' }}>
       <section style={{ display: 'flex', alignItems: 'center', justifyContent: 'center', borderRight: '4px solid #0f172a', position: 'relative' }}>
-        <div style={{ position: 'absolute', top: 20, left: 24, fontSize: 28, fontWeight: 800, opacity: 0.9 }}>{snap?.counterName ?? 'ช่องยา'}</div>
+        <div style={{ position: 'absolute', top: 20, left: 24, fontSize: 28, fontWeight: 800, opacity: 0.9 }}>{snap?.counterName ?? (room === 'exam' ? 'ห้องตรวจ' : 'ช่องยา')}</div>
         <div>
           <div style={{ textAlign: 'center', opacity: 0.8, fontSize: 28, letterSpacing: 1 }}>ขณะนี้กำลังเรียก</div>
           <div style={{ fontSize: '22vw', lineHeight: 1, fontWeight: 900, textAlign: 'center', marginTop: 10 }}>
@@ -53,7 +62,7 @@ export default function DisplayPage() {
           </div>
         </div>
       </section>
-      <section style={{ padding: '32px 28px' }}>
+      <section style={{ padding: '32px 28px', position: 'relative' }}>
         <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
           <h2 style={{ margin: 0, fontSize: 32, fontWeight: 800 }}>คิวถัดไป</h2>
           <div style={{ display: 'flex', gap: 10 }}>
@@ -62,7 +71,7 @@ export default function DisplayPage() {
               เสียงเตือนเมื่อเปลี่ยนหมายเลข
             </label>
             <button onClick={toggleFull} style={btn()}>เต็มจอ</button>
-            <button onClick={() => location.reload()} style={btn()}>รีเฟรช</button>
+            <button onClick={refresh} style={btn()}>รีเฟรช</button>
           </div>
         </div>
 
@@ -73,10 +82,10 @@ export default function DisplayPage() {
         </div>
 
         <div style={{ position: 'absolute', bottom: 16, right: 28, opacity: 0.6, fontSize: 12 }}>
-          ห้องยา · แสดงผลอัตโนมัติทุก 1.5 วินาที
+          {room === 'exam' ? 'ห้องตรวจ' : 'ห้องยา'} · แสดงผลอัตโนมัติทุก 1.5 วินาที
         </div>
       </section>
-    </main>
+    </div>
   );
 }
 

--- a/data/settings.json
+++ b/data/settings.json
@@ -1,3 +1,4 @@
 {
-  "counterName": "ช่องยา 2"
+  "exam": { "counterName": "ห้องตรวจ 1" },
+  "pharmacy": { "counterName": "ช่องยา 1" }
 }

--- a/lib/tts.ts
+++ b/lib/tts.ts
@@ -3,9 +3,9 @@ let tailText = 'กรุณาติดต่อรับยา';
 
 export function setTailText(t: string) { tailText = t; }
 
-export async function speakCall(number: number) {
+export async function speakCall(number: number, tail?: string) {
   if (typeof window === 'undefined') return;
-  const text = `ขอเชิญหมายเลข ${number} ${tailText}`;
+  const text = `ขอเชิญหมายเลข ${number} ${tail ?? tailText}`;
   const res = await fetch('/api/gt-tts', {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -1,0 +1,1 @@
+export type Room = 'exam' | 'pharmacy';


### PR DESCRIPTION
## Summary
- add multi-room queue state and APIs for exam and pharmacy
- render side-by-side control panels for exam and pharmacy queues
- show separate exam and pharmacy sections on the public display

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (failed: requested interactive configuration)


------
https://chatgpt.com/codex/tasks/task_e_68a02dbfbe6883289dae936f9d332aeb