### PR TITLE
feat: separate tail text per room

### DIFF
--- a/app/display/page.tsx
+++ b/app/display/page.tsx
@@ -6,7 +6,8 @@ type Snapshot = { current: number|null; items: { number: number; status: string;
 
 export default function DisplayPage() {
   return (
-    <main style={{ width: '100%', height: '100vh', background: '#030712', color: '#e5e7eb', display: 'grid', gridTemplateColumns: '1fr 1fr' }}>
+    <main style={{ width: '100%', height: '100vh', background: '#030712', color: '#e5e7eb', display: 'grid', gridTemplateColumns: '1fr 1fr', position: 'relative' }}>
+      <div style={{ position: 'absolute', top: 0, bottom: 0, left: '50%', width: 4, background: 'white', transform: 'translateX(-50%)' }} />
       <Board room="exam" />
       <Board room="pharmacy" />
     </main>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -6,21 +6,24 @@ import type { Room } from '@/lib/types';
 
 type Snapshot = { current: number|null; items: { number: number; status: string; createdAt: number }[]; tailNumber: number; counterName: string };
 
-const tailText: Record<Room,string> = { exam: 'กรุณาติดต่อห้องตรวจ', pharmacy: 'กรุณาติดต่อรับยา' };
-
 export default function Page() {
+  const [tails, setTails] = React.useState<Record<Room, string>>({
+    exam: 'กรุณาติดต่อห้องตรวจ',
+    pharmacy: 'กรุณาติดต่อรับยา'
+  });
+
   return (
     <main style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 20, margin: '20px auto', padding: 20, maxWidth: 1400 }}>
-      <QueueControl room="exam" title="ระบบเรียกคิวห้องตรวจ" />
-      <QueueControl room="pharmacy" title="ระบบเรียกคิวห้องยา" />
+      <QueueControl room="exam" title="ระบบเรียกคิวห้องตรวจ" tail={tails.exam} />
+      <QueueControl room="pharmacy" title="ระบบเรียกคิวห้องยา" tail={tails.pharmacy} />
       <div style={{ gridColumn: '1 / -1' }}>
-        <AudioAnnouncer />
+        <AudioAnnouncer tails={tails} setTails={setTails} />
       </div>
     </main>
   );
 }
 
-function QueueControl({ room, title }: { room: Room; title: string }) {
+function QueueControl({ room, title, tail }: { room: Room; title: string; tail: string }) {
   const [snap, setSnap] = React.useState<Snapshot | null>(null);
   const [loading, setLoading] = React.useState(false);
 
@@ -40,8 +43,8 @@ function QueueControl({ room, title }: { room: Room; title: string }) {
     if (after) after(data.current);
   };
 
-  const callNext = async () => action(`/api/queue/next?room=${room}`, async (n) => { if (n) await speakCall(n, tailText[room]); });
-  const callRepeat = async () => action(`/api/queue/repeat?room=${room}`, async (n) => { if (n) await speakCall(n, tailText[room]); });
+  const callNext = async () => action(`/api/queue/next?room=${room}`, async (n) => { if (n) await speakCall(n, tail); });
+  const callRepeat = async () => action(`/api/queue/repeat?room=${room}`, async (n) => { if (n) await speakCall(n, tail); });
   const callSkip = async () => action(`/api/queue/skip?room=${room}`);
   const callDone = async () => action(`/api/queue/done?room=${room}`);
 

--- a/components/AudioAnnouncer.tsx
+++ b/components/AudioAnnouncer.tsx
@@ -1,17 +1,25 @@
 
 'use client';
 import React from 'react';
-import { setTailText, speakCall } from '@/lib/tts';
+import { speakCall } from '@/lib/tts';
+import type { Room } from '@/lib/types';
 
-export default function AudioAnnouncer() {
+type Props = {
+  tails: Record<Room, string>;
+  setTails: React.Dispatch<React.SetStateAction<Record<Room, string>>>;
+};
+
+export default function AudioAnnouncer({ tails, setTails }: Props) {
   const [enabled, setEnabled] = React.useState(false);
-  const [tail, setTail] = React.useState('กรุณาติดต่อรับยา');
   const [testNum, setTestNum] = React.useState(1);
-
-  React.useEffect(() => { setTailText(tail); }, [tail]);
 
   const enableAudio = async () => {
     try { setEnabled(true); } catch {}
+  };
+
+  const updateTail = (room: Room) => (e: React.ChangeEvent<HTMLInputElement>) => {
+    const val = e.target.value;
+    setTails(t => ({ ...t, [room]: val }));
   };
 
   return (
@@ -19,14 +27,19 @@ export default function AudioAnnouncer() {
       <div style={{ display: 'flex', gap: 12, alignItems: 'center', flexWrap: 'wrap' }}>
         <button onClick={enableAudio} style={btnStyle}>{enabled ? 'พร้อมเล่นเสียง ✅' : 'เปิดเสียง 🔊'}</button>
         <label style={{ display: 'flex', gap: 8, alignItems: 'center' }}>
-          หางเสียง:
-          <input value={tail} onChange={e => setTail(e.target.value)} style={inputStyle} placeholder="ข้อความต่อท้าย" />
+          หางเสียงห้องตรวจ:
+          <input value={tails.exam} onChange={updateTail('exam')} style={inputStyle} placeholder="ข้อความต่อท้าย" />
+        </label>
+        <label style={{ display: 'flex', gap: 8, alignItems: 'center' }}>
+          หางเสียงห้องยา:
+          <input value={tails.pharmacy} onChange={updateTail('pharmacy')} style={inputStyle} placeholder="ข้อความต่อท้าย" />
         </label>
         <label style={{ display: 'flex', gap: 8, alignItems: 'center' }}>
           ทดสอบหมายเลข:
           <input type="number" value={testNum} onChange={e => setTestNum(parseInt(e.target.value||'0'))} style={inputStyle} />
         </label>
-        <button onClick={() => enabled && speakCall(testNum)} style={btnStyle}>ทดสอบเสียงประกาศ</button>
+        <button onClick={() => enabled && speakCall(testNum, tails.exam)} style={btnStyle}>ทดสอบห้องตรวจ</button>
+        <button onClick={() => enabled && speakCall(testNum, tails.pharmacy)} style={btnStyle}>ทดสอบห้องยา</button>
       </div>
       {!enabled && <p style={{ marginTop: 8, opacity: 0.8 }}>ต้องกด “เปิดเสียง” ก่อนเพื่อให้เบราว์เซอร์อนุญาตเล่นเสียง</p>}
     </div>

--- a/lib/tts.ts
+++ b/lib/tts.ts
@@ -1,11 +1,7 @@
 
-let tailText = 'กรุณาติดต่อรับยา';
-
-export function setTailText(t: string) { tailText = t; }
-
-export async function speakCall(number: number, tail?: string) {
+export async function speakCall(number: number, tail = 'กรุณาติดต่อรับยา') {
   if (typeof window === 'undefined') return;
-  const text = `ขอเชิญหมายเลข ${number} ${tail ?? tailText}`;
+  const text = `ขอเชิญหมายเลข ${number} ${tail}`;
   const res = await fetch('/api/gt-tts', {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },


### PR DESCRIPTION
## Summary
- allow customizing tail phrases for exam and pharmacy rooms separately
- add a central white divider on the public display screen
- simplify TTS helper to accept tail text directly

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(requires interactive ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68a0340c542c83288cc248a6b7024ac3