### PR TITLE
Enable calling skipped queue numbers directly

### DIFF
--- a/app/api/queue/call/route.ts
+++ b/app/api/queue/call/route.ts
@@ -1,0 +1,17 @@
+export const runtime = 'nodejs';
+import { NextRequest, NextResponse } from 'next/server';
+import { recallSkipped } from '@/lib/store';
+import { Room } from '@/lib/types';
+export const dynamic = 'force-dynamic';
+
+function getRoom(req: NextRequest): Room {
+  const r = req.nextUrl.searchParams.get('room');
+  return r === 'exam' || r === 'pharmacy' ? r : 'pharmacy';
+}
+
+export async function POST(req: NextRequest) {
+  const room = getRoom(req);
+  const num = Number(req.nextUrl.searchParams.get('number'));
+  const n = recallSkipped(room, num);
+  return NextResponse.json({ ok: true, current: n });
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -47,6 +47,7 @@ function QueueControl({ room, title, tail }: { room: Room; title: string; tail: 
   const callRepeat = async () => action(`/api/queue/repeat?room=${room}`, async (n) => { if (n) await speakCall(n, tail); });
   const callSkip = async () => action(`/api/queue/skip?room=${room}`);
   const callDone = async () => action(`/api/queue/done?room=${room}`);
+  const callSkippedNumber = async (n:number) => action(`/api/queue/call?room=${room}&number=${n}`, async (m) => { if (m) await speakCall(m, tail); });
 
   const add = async () => {
     setLoading(true);
@@ -104,7 +105,7 @@ function QueueControl({ room, title, tail }: { room: Room; title: string; tail: 
             <Panel title="กำลังเรียก" items={called} highlight />
             <Panel title="รอเรียก" items={waiting} />
             <Panel title="เสร็จสิ้น" items={done} />
-            <Panel title="ถูกข้าม" items={skipped} />
+            <Panel title="ถูกข้าม" items={skipped} onItemClick={callSkippedNumber} />
           </div>
         </div>
       </div>
@@ -112,13 +113,21 @@ function QueueControl({ room, title, tail }: { room: Room; title: string; tail: 
   );
 }
 
-function Panel({ title, items, highlight=false }: { title: string; items: number[]; highlight?: boolean }) {
+function Panel({ title, items, highlight=false, onItemClick }: { title: string; items: number[]; highlight?: boolean; onItemClick?: (n:number)=>void }) {
   return (
     <div style={{ background: highlight ? '#0e1c4f' : '#0b1020', borderRadius: 12, padding: 12 }}>
       <div style={{ fontWeight: 700, marginBottom: 8 }}>{title}</div>
       <div style={{ display: 'flex', gap: 8, flexWrap: 'wrap' }}>
         {items.length === 0 ? <span style={{ opacity: 0.7 }}>-</span> :
-          items.map(n => <span key={n} style={pill}>{n}</span>)}
+          items.map(n => (
+            <span
+              key={n}
+              style={{...pill, cursor: onItemClick ? 'pointer' : undefined}}
+              onClick={() => onItemClick?.(n)}
+            >
+              {n}
+            </span>
+          ))}
       </div>
     </div>
   );

--- a/lib/store.ts
+++ b/lib/store.ts
@@ -86,6 +86,19 @@ export function nextQueue(room: Room) {
 
 export function repeatCurrent(room: Room) { return state[room].current; }
 
+export function recallSkipped(room: Room, num: number) {
+  const st = state[room];
+  const item = st.items.find(i => i.number === num && i.status === 'skipped');
+  if (!item) return st.current;
+  if (st.current !== null) {
+    const cur = st.items.find(i => i.number === st.current);
+    if (cur && cur.status === 'calling') cur.status = 'waiting';
+  }
+  item.status = 'calling';
+  st.current = num;
+  return st.current;
+}
+
 export function skipCurrent(room: Room) {
   const st = state[room];
   if (st.current === null) return null;


### PR DESCRIPTION
## Summary
- allow clicking skipped numbers to recall them
- add API and store logic to re-call skipped queue entries

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: requires interactive ESLint setup)*
- `npm run build` *(fails: Module not found: @google-cloud/text-to-speech)*

------
https://chatgpt.com/codex/tasks/task_e_68a045e51d248328bb46a045e627f401