### PR TITLE
Enable clicking waiting queue numbers to call

### DIFF
--- a/app/api/queue/call/route.ts
+++ b/app/api/queue/call/route.ts
@@ -1,6 +1,6 @@
 export const runtime = 'nodejs';
 import { NextRequest, NextResponse } from 'next/server';
-import { recallSkipped } from '@/lib/store';
+import { callNumber } from '@/lib/store';
 import { Room } from '@/lib/types';
 export const dynamic = 'force-dynamic';
 
@@ -12,6 +12,6 @@ function getRoom(req: NextRequest): Room {
 export async function POST(req: NextRequest) {
   const room = getRoom(req);
   const num = Number(req.nextUrl.searchParams.get('number'));
-  const n = recallSkipped(room, num);
+  const n = callNumber(room, num);
   return NextResponse.json({ ok: true, current: n });
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -47,7 +47,7 @@ function QueueControl({ room, title, tail }: { room: Room; title: string; tail: 
   const callRepeat = async () => action(`/api/queue/repeat?room=${room}`, async (n) => { if (n) await speakCall(n, tail); });
   const callSkip = async () => action(`/api/queue/skip?room=${room}`);
   const callDone = async () => action(`/api/queue/done?room=${room}`);
-  const callSkippedNumber = async (n:number) => action(`/api/queue/call?room=${room}&number=${n}`, async (m) => { if (m) await speakCall(m, tail); });
+  const callNumber = async (n:number) => action(`/api/queue/call?room=${room}&number=${n}`, async (m) => { if (m) await speakCall(m, tail); });
 
   const add = async () => {
     setLoading(true);
@@ -103,9 +103,9 @@ function QueueControl({ room, title, tail }: { room: Room; title: string; tail: 
           </div>
           <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 12 }}>
             <Panel title="กำลังเรียก" items={called} highlight />
-            <Panel title="รอเรียก" items={waiting} />
+            <Panel title="รอเรียก" items={waiting} onItemClick={callNumber} />
             <Panel title="เสร็จสิ้น" items={done} />
-            <Panel title="ถูกข้าม" items={skipped} onItemClick={callSkippedNumber} />
+            <Panel title="ถูกข้าม" items={skipped} onItemClick={callNumber} />
           </div>
         </div>
       </div>

--- a/lib/store.ts
+++ b/lib/store.ts
@@ -86,9 +86,11 @@ export function nextQueue(room: Room) {
 
 export function repeatCurrent(room: Room) { return state[room].current; }
 
-export function recallSkipped(room: Room, num: number) {
+export function callNumber(room: Room, num: number) {
   const st = state[room];
-  const item = st.items.find(i => i.number === num && i.status === 'skipped');
+  const item = st.items.find(
+    i => i.number === num && (i.status === 'skipped' || i.status === 'waiting')
+  );
   if (!item) return st.current;
   if (st.current !== null) {
     const cur = st.items.find(i => i.number === st.current);


### PR DESCRIPTION
## Summary
- allow staff to click numbers in the waiting list to immediately call a queue
- generalize API and store logic to call any waiting or skipped number

## Testing
- `npm test` *(fails: Missing script "test" )*
- `npm run lint` *(fails: prompts for ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68a07f98a76883288a887f326092ec6e