### PR TITLE
feat: confirm before refreshing queue

### DIFF
--- a/app/api/queue/route.ts
+++ b/app/api/queue/route.ts
@@ -1,6 +1,6 @@
 export const runtime = 'nodejs';
 import { NextRequest, NextResponse } from 'next/server';
-import { addQueue, getSnapshot } from '@/lib/store';
+import { addQueue, getSnapshot, resetQueue } from '@/lib/store';
 import { Room } from '@/lib/types';
 
 export const dynamic = 'force-dynamic';
@@ -20,6 +20,10 @@ export async function POST(req: NextRequest) {
   if (body.action === 'add') {
     const item = addQueue(room);
     return NextResponse.json({ ok: true, added: item });
+  }
+  if (body.action === 'reset') {
+    resetQueue(room);
+    return NextResponse.json({ ok: true });
   }
   return NextResponse.json({ ok: false, error: 'Unknown action' }, { status: 400 });
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -56,6 +56,19 @@ function QueueControl({ room, title, tail }: { room: Room; title: string; tail: 
     await refresh();
   };
 
+  const reset = async () => {
+    const ok = window.confirm('ต้องการรีเฟรชข้อมูลทั้งหมดหรือไม่?');
+    if (!ok) return;
+    setLoading(true);
+    await fetch(`/api/queue?room=${room}`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ action: 'reset' })
+    });
+    setLoading(false);
+    await refresh();
+  };
+
   const current = snap?.current ?? null;
   const waiting = (snap?.items ?? []).filter(i => i.status === 'waiting').map(i => i.number);
   const called = (snap?.items ?? []).filter(i => i.status === 'calling').map(i => i.number);
@@ -99,7 +112,7 @@ function QueueControl({ room, title, tail }: { room: Room; title: string; tail: 
           <h2 style={{ marginTop: 0 }}>จัดการคิว</h2>
           <div style={{ display: 'flex', gap: 8, marginBottom: 12 }}>
             <button onClick={add} disabled={loading} style={btnPri}>ลงทะเบียนคิวใหม่</button>
-            <button onClick={refresh} disabled={loading} style={btnSec}>รีเฟรช</button>
+            <button onClick={reset} disabled={loading} style={btnSec}>รีเฟรช</button>
           </div>
           <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 12 }}>
             <Panel title="กำลังเรียก" items={called} highlight />

--- a/lib/store.ts
+++ b/lib/store.ts
@@ -123,6 +123,13 @@ export function doneCurrent(room: Room) {
   return st.current;
 }
 
+export function resetQueue(room: Room) {
+  const st = state[room];
+  st.current = null;
+  st.items = [];
+  st.tailNumber = 0;
+}
+
 export function setCounterName(room: Room, name: string) {
   state[room].counterName = name || (room === 'exam' ? 'ห้องตรวจ 1' : 'ช่องยา 1');
   saveSettingsFromState(state);


### PR DESCRIPTION
## Summary
- add state reset function for queue rooms
- extend queue API to support reset action
- prompt user to confirm refresh and clear queue data on control page

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: requires interactive setup)*
- `npm run build` *(fails: Can't resolve '@google-cloud/text-to-speech')*

------
https://chatgpt.com/codex/tasks/task_e_68a081a99c9083289661c7b43c801a9d